### PR TITLE
index/vertex data TODO

### DIFF
--- a/Headers/mvEngine.h
+++ b/Headers/mvEngine.h
@@ -29,9 +29,10 @@ namespace mv
             VkDescriptorSet descriptorSet;
             mv::Buffer uniformBuffer; // contains the matrices
             glm::vec3 rotation;
+            uint32_t modelIndex;
         };
-        std::array<Object, 1> objects;
-        mv::Model model;
+        std::vector<Object> objects;
+        std::vector<mv::Model> models;
 
         VkPipeline pipeline = nullptr;
         VkPipelineLayout pipelineLayout = nullptr;

--- a/Headers/mvModel.h
+++ b/Headers/mvModel.h
@@ -103,7 +103,7 @@ namespace mv
             return;
         }
 
-        void load(mv::Device *dvc, uint32_t swapchain_image_count)
+        void load(mv::Device *dvc, const char* filename)
         {
             assert(dvc);
 
@@ -128,7 +128,7 @@ namespace mv
             //     4, 5, 6, 6, 7, 4};
             std::string warn, err;
 
-            if (!tinyobj::LoadObj(&attribute, &shapes, &materials, &warn, &err, MODEL_PATH.c_str()))
+            if (!tinyobj::LoadObj(&attribute, &shapes, &materials, &warn, &err, filename))
             {
                 throw std::runtime_error(warn + err);
             }
@@ -150,6 +150,9 @@ namespace mv
                     t_vertices.push_back(vertex);
                     vertices.count++;
 
+                    // TODO
+                    // Remove duplicate vertices to properly allow
+                    // indexed drawing
                     t_indices.push_back(t_indices.size());
                     indices.count++;
                 }


### PR DESCRIPTION
Added todo for index data when loading 3d models.

current function performs no removal of duplicate vertices negating any performance benefits of indexed drawing.